### PR TITLE
Add optional from & until date params on getLinks() for LinksAdapter

### DIFF
--- a/src/ad4m/Language.ts
+++ b/src/ad4m/Language.ts
@@ -120,7 +120,7 @@ export interface LinksAdapter {
     updateLink(oldLinkExpression: Expression, newLinkExpression: Expression);
     removeLink(link: Expression);
 
-    getLinks(query: LinkQuery): Promise<Expression[]>;
+    getLinks(query: LinkQuery, from?: Date, until?: Date): Promise<Expression[]>;
 
     // Get push notified by added links
     addCallback(callback: NewLinksObserver);


### PR DESCRIPTION
Didn't think we really needed any special shape for these params, inbuilt types work fine.

Figured its fine in the getLinks() function since its optional and thus if someone wishes to implement a full getLinks() they can write the language to do so when nothing is passed as from & until.  